### PR TITLE
asprintf: Fix undefined behavior

### DIFF
--- a/src/asprintf.c
+++ b/src/asprintf.c
@@ -28,8 +28,9 @@ dm_asprintf(char **restrict strp, const char *restrict fmt, ...)
 	va_list args;
 	int size = 0;
 	va_start(args, fmt);
+	size = dm_vasprintf(strp, fmt, args);
 	va_end(args);
-	return size = dm_vasprintf(strp, fmt, args);
+	return size;
 }
 
 int


### PR DESCRIPTION
According to 7.15.1.3 in C99 standard or 7.16.1.3 in C17 standard:
```
The va_end macro may modify ap so that it is no longer usable (without being reinitialized by the va_start or va_copy macro).
```